### PR TITLE
Adicionei testes Cucumber BDD

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.debug.settings.onBuildFailureProceed": true
+}

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -62,6 +62,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Springdoc OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -69,24 +76,46 @@
             <scope>test</scope>
         </dependency>
 
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
-		</dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-	</dependencies>
+        <!-- Cucumber Dependencies -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.14.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>7.14.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>7.14.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/maven/src/main/java/com/voltunity/evplatform/model/Station.java
+++ b/maven/src/main/java/com/voltunity/evplatform/model/Station.java
@@ -1,7 +1,14 @@
 package com.voltunity.evplatform.model;
 
-import jakarta.persistence.*;
 import java.util.List;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "stations")
@@ -20,7 +27,7 @@ public class Station {
     private float maxPower;
     private double pricePerKWh;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private List<String> chargerTypes;
 
     public Station() {}

--- a/maven/src/main/java/com/voltunity/evplatform/repository/BookingRepository.java
+++ b/maven/src/main/java/com/voltunity/evplatform/repository/BookingRepository.java
@@ -13,10 +13,8 @@ import java.util.Optional;
 @Repository
 public interface BookingRepository extends JpaRepository<Booking, Long> {
 
-       @Query("SELECT b FROM Booking b WHERE b.slot = :slot AND " +
-            "(:start < b.end_time AND :end_time > b.start)")
-    List<Booking> findBySlotAndTimeOverlap(Slot slot, LocalDateTime start, LocalDateTime end);
-
+       @Query("SELECT b FROM Booking b WHERE b.slot = :slot AND (:start < b.end_time AND :end > b.start)")
+       List<Booking> findBySlotAndTimeOverlap(Slot slot, LocalDateTime start, LocalDateTime end);
 
        @Query("SELECT b FROM Booking b WHERE b.slot = :slot " +
               "AND b.bookingStatus = 'confirmed' " +

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/CucumberSpringConfiguration.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/CucumberSpringConfiguration.java
@@ -1,0 +1,11 @@
+package com.voltunity.evplatform.cucumber;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@CucumberContextConfiguration
+@SpringBootTest
+@ActiveProfiles("test") 
+public class CucumberSpringConfiguration {
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/CucumberTestRunner.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/CucumberTestRunner.java
@@ -1,0 +1,14 @@
+package com.voltunity.evplatform.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    plugin = {"pretty"},
+    features = "classpath:com/voltunity/evplatform/cucumber/features",
+    glue = {"com.voltunity.evplatform.cucumber", "com.voltunity.evplatform.cucumber.stepdefs"}
+)
+public class CucumberTestRunner {
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/TestContext.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/TestContext.java
@@ -1,0 +1,13 @@
+package com.voltunity.evplatform.cucumber;
+
+import org.springframework.stereotype.Component;
+
+import com.voltunity.evplatform.model.Booking;
+
+@Component
+public class TestContext {
+    public Long userId;
+    public Long stationId;
+    public double paymentAmount;
+    public Booking booking;
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/features/booking.feature
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/features/booking.feature
@@ -1,0 +1,25 @@
+Feature: Booking Slot
+
+  Scenario: Create a valid booking
+    Given a station with available slots exists
+    And a registered user exists
+    When I book a slot from "2025-06-10T10:00" to "2025-06-10T11:00"
+    Then the booking should be confirmed
+
+  Scenario: Attempt to book with invalid time range
+    Given a station with available slots exists
+    And a registered user exists
+    When I book a slot from "2025-06-10T12:00" to "2025-06-10T10:00"
+    Then an error should occur with message "Intervalo de tempo inválido"
+
+  Scenario: Attempt to book when no slots are available
+    Given a station without available slots exists
+    And a registered user exists
+    When I book a slot from "2025-06-10T10:00" to "2025-06-10T11:00"
+    Then an error should occur with message "Nenhum slot disponível na estação para o período selecionado"
+
+  Scenario: Cancel a confirmed booking
+    Given a confirmed booking exists
+    When I cancel the booking
+    Then the booking status should be "cancelled"
+    And the associated slot should be "AVAILABLE"

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/features/maintenance.feature
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/features/maintenance.feature
@@ -1,0 +1,6 @@
+Feature: Station maintenance management
+
+  Scenario: Mark a station as under maintenance
+    Given a station "Maintenance Test Station" exists with status "ACTIVE"
+    When I mark the station "Maintenance Test Station" as "IN_MAINTENANCE"
+    Then the station "Maintenance Test Station" should have status "IN_MAINTENANCE"

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/features/payment.feature
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/features/payment.feature
@@ -1,0 +1,9 @@
+Feature: Booking with payment
+
+  Scenario: Create a booking with payment
+    Given a station with available slots exists
+    And a registered user exists
+    When the user pays "7.50" EUR
+    And the user books a slot from "2025-06-12T14:00" to "2025-06-12T15:00"
+    Then the booking should be confirmed
+    And the booking price should be 7.50

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/features/station_search.feature
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/features/station_search.feature
@@ -1,0 +1,7 @@
+Feature: Station search by filters
+
+  Scenario: Search stations by charger type and availability
+    Given a station "Fast CCS Station" with type "CCS" and 1 available slot exists
+    And a station "Slow Type2 Station" with type "TYPE2" and no available slots exists
+    When I search for stations with type "CCS" and availability "true"
+    Then I should find 1 station named "Fast CCS Station"

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/AdminSteps.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/AdminSteps.java
@@ -1,0 +1,52 @@
+package com.voltunity.evplatform.cucumber.stepdefs;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.voltunity.evplatform.model.Station;
+import com.voltunity.evplatform.service.StationService;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+@SpringBootTest
+public class AdminSteps {
+
+    @Autowired
+    private StationService stationService;
+
+    @Given("a station {string} exists with status {string}")
+    public void aStationExistsWithStatus(String name, String status) {
+        Station station = new Station();
+        station.setName(name);
+        station.setStationStatus(status);
+        station.setLat(0.0f);
+        station.setLng(0.0f);
+        station.setChargerTypes(List.of("CCS"));
+        stationService.saveStation(station);
+    }
+
+    @When("I mark the station {string} as {string}")
+    public void iMarkTheStationAs(String name, String newStatus) {
+        List<Station> all = stationService.getAllStations();
+        Station target = all.stream()
+            .filter(s -> s.getName().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Station not found"));
+        stationService.updateStationStatus(target.getId(), newStatus);
+    }
+
+    @Then("the station {string} should have status {string}")
+    public void theStationShouldHaveStatus(String name, String expectedStatus) {
+        List<Station> all = stationService.getAllStations();
+        Station target = all.stream()
+            .filter(s -> s.getName().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Station not found"));
+        assertEquals(expectedStatus, target.getStationStatus());
+    }
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/BookingSteps.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/BookingSteps.java
@@ -1,0 +1,138 @@
+package com.voltunity.evplatform.cucumber.stepdefs;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.voltunity.evplatform.cucumber.TestContext;
+import com.voltunity.evplatform.model.Booking;
+import com.voltunity.evplatform.model.Slot;
+import com.voltunity.evplatform.model.Station;
+import com.voltunity.evplatform.model.User;
+import com.voltunity.evplatform.repository.SlotRepository;
+import com.voltunity.evplatform.repository.StationRepository;
+import com.voltunity.evplatform.repository.UserRepository;
+import com.voltunity.evplatform.service.BookingService;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+@SpringBootTest
+public class BookingSteps {
+
+    @Autowired private StationRepository stationRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private SlotRepository slotRepository;
+    @Autowired private BookingService bookingService;
+    @Autowired private TestContext testContext;
+
+    private Exception exception;
+
+    @Given("a station with available slots exists")
+    public void aStationWithAvailableSlotsExists() {
+        Station station = new Station();
+        station.setName("Booking Station");
+        station.setStationStatus("ACTIVE");
+        testContext.stationId = stationRepository.save(station).getId();
+
+        Slot slot = new Slot();
+        slot.setSlotStatus("AVAILABLE");
+        slot.setStation(station);
+        slotRepository.save(slot);
+    }
+
+    @Given("a station without available slots exists")
+    public void aStationWithoutAvailableSlotsExists() {
+        Station station = new Station();
+        station.setName("Unavailable Station");
+        station.setStationStatus("ACTIVE");
+        testContext.stationId = stationRepository.save(station).getId();
+
+        Slot slot = new Slot();
+        slot.setSlotStatus("IN_USE");
+        slot.setStation(station);
+        slotRepository.save(slot);
+    }
+
+    @Given("a registered user exists")
+    public void aRegisteredUserExists() {
+        User user = new User();
+        user.setEmail("user@example.com");
+        testContext.userId = userRepository.save(user).getId();
+    }
+
+    @When("I book a slot from {string} to {string}")
+    public void iBookASlotFromTo(String startStr, String endStr) {
+        try {
+            testContext.booking = bookingService.createBooking(
+                testContext.stationId,
+                LocalDateTime.parse(startStr),
+                LocalDateTime.parse(endStr),
+                testContext.userId
+            );
+        } catch (Exception e) {
+            exception = e;
+        }
+    }
+
+    @Then("the booking should be confirmed")
+    public void theBookingShouldBeConfirmed() {
+        assertNotNull(testContext.booking);
+        assertEquals("confirmed", testContext.booking.getBookingStatus());
+    }
+
+    @Then("an error should occur with message {string}")
+    public void anErrorShouldOccurWithMessage(String expectedMessage) {
+        assertNotNull(exception, "Expected an exception but none was thrown");
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Given("a confirmed booking exists")
+    public void aConfirmedBookingExists() {
+        Station station = new Station();
+        station.setName("Cancel Station");
+        station.setStationStatus("ACTIVE");
+        station = stationRepository.save(station);
+
+        Slot slot = new Slot();
+        slot.setSlotStatus("AVAILABLE");
+        slot.setStation(station);
+        slot = slotRepository.save(slot);
+
+        User user = new User();
+        user.setEmail("cancel@example.com");
+        user = userRepository.save(user);
+
+        Booking b = new Booking();
+        b.setSlot(slot);
+        b.setUser(user);
+        b.setStart(LocalDateTime.now().plusHours(1));
+        b.setEnd_time(LocalDateTime.now().plusHours(2));
+        b.setBookingStatus("confirmed");
+        b.setPriceAtBooking(5.0f);
+        testContext.booking = bookingService.saveBooking(b);
+
+        testContext.stationId = station.getId();
+        testContext.userId = user.getId();
+    }
+
+    @When("I cancel the booking")
+    public void iCancelTheBooking() {
+        testContext.booking = bookingService.cancelBooking(testContext.booking.getId());
+    }
+
+    @Then("the booking status should be {string}")
+    public void theBookingStatusShouldBe(String expectedStatus) {
+        assertEquals(expectedStatus, testContext.booking.getBookingStatus());
+    }
+
+    @Then("the associated slot should be {string}")
+    public void theAssociatedSlotShouldBe(String expectedStatus) {
+        Slot updatedSlot = testContext.booking.getSlot();
+        assertEquals(expectedStatus, updatedSlot.getSlotStatus());
+    }
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/PaymentSteps.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/PaymentSteps.java
@@ -1,0 +1,48 @@
+package com.voltunity.evplatform.cucumber.stepdefs;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.voltunity.evplatform.cucumber.TestContext;
+import com.voltunity.evplatform.model.Booking;
+import com.voltunity.evplatform.service.BookingService;
+import com.voltunity.evplatform.service.PaymentService;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+@SpringBootTest
+public class PaymentSteps {
+
+    @Autowired private BookingService bookingService;
+    @Autowired private PaymentService paymentService;
+    @Autowired private TestContext testContext;
+
+    @When("the user pays {string} EUR")
+    public void theUserPaysEUR(String amountStr) {
+        testContext.paymentAmount = Double.parseDouble(amountStr);
+        paymentService.createPayment(testContext.userId, testContext.paymentAmount, "EUR");
+    }
+
+    @When("the user books a slot from {string} to {string}")
+    public void theUserBooksASlot(String from, String to) {
+        Booking booking = bookingService.createBooking(
+            testContext.stationId,
+            LocalDateTime.parse(from),
+            LocalDateTime.parse(to),
+            testContext.userId
+        );
+        booking.setPriceAtBooking((float) testContext.paymentAmount);
+        testContext.booking = bookingService.saveBooking(booking);
+    }
+
+    @Then("the booking price should be {double}")
+    public void theBookingPriceShouldBe(Double expected) {
+        assertNotNull(testContext.booking);
+        assertEquals(expected, testContext.booking.getPriceAtBooking(), 0.001);
+    }
+}

--- a/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/SearchSteps.java
+++ b/maven/src/test/java/com/voltunity/evplatform/cucumber/stepdefs/SearchSteps.java
@@ -1,0 +1,60 @@
+package com.voltunity.evplatform.cucumber.stepdefs;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.voltunity.evplatform.model.Slot;
+import com.voltunity.evplatform.model.Station;
+import com.voltunity.evplatform.repository.SlotRepository;
+import com.voltunity.evplatform.service.StationService;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class SearchSteps {
+
+    @Autowired private StationService stationService;
+    @Autowired private SlotRepository slotRepository;
+
+    private List<Station> searchResults;
+
+    @Given("a station {string} with type {string} and 1 available slot exists")
+    public void aStationAvailable(String name, String type) {
+        Station station = new Station(name, "ACTIVE", 0, 0, "Rua A", 1, 22, List.of(type));
+        station = stationService.saveStation(station);
+
+        Slot slot = new Slot();
+        slot.setStation(station);
+        slot.setSlotStatus("AVAILABLE");
+        slotRepository.save(slot);
+    }
+
+    @Given("a station {string} with type {string} and no available slots exists")
+    public void aStationUnavailable(String name, String type) {
+        Station station = new Station(name, "ACTIVE", 0, 0, "Rua B", 1, 22, List.of(type));
+        station = stationService.saveStation(station);
+
+        Slot slot = new Slot();
+        slot.setStation(station);
+        slot.setSlotStatus("IN_USE");
+        slotRepository.save(slot);
+    }
+
+    @When("I search for stations with type {string} and availability {string}")
+    public void iSearch(String type, String availability) {
+        boolean disp = Boolean.parseBoolean(availability);
+        searchResults = stationService.searchStations(0, 0, 1000, type, disp, null);
+    }
+
+    @Then("I should find {int} station named {string}")
+    public void iShouldFindStation(int count, String name) {
+        assertEquals(count, searchResults.size());
+        assertTrue(searchResults.stream().anyMatch(s -> s.getName().equals(name)));
+    }
+}
+
+

--- a/maven/src/test/resources/application-test.properties
+++ b/maven/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Este PR adiciona testes _Cucumber_ BDD abrangendo:

- Cenários de reserva (válido, inválido, cancelado)
- Pagamento por utilização
- Pesquisa de estações por tipo de carregador e disponibilidade
- Gestão de manutenção de estações (administrador)

### Adições e melhorias técnicas
- **TestContext** classe utilizada para o estado partilhado entre as etapas.
- Criação do **application-test.properties** para utilizar **H2 DB em memória** durante os testes _Cucumber_
- `@ElementCollection(fetch = FetchType.EAGER)` adicionado a **Station.chargerTypes** para corrigir **LazyInitializationException** durante os testes de pesquisa.
- Parâmetro **:end_time** passou a ser **:end** na consulta JPQL personalizada de ``BookingRepository.findBySlotAndTimeOverlap(...)`` para se alinhar com a assinatura do método e evitar **QueryParameterException**.

### Todos os testes passam